### PR TITLE
Chore/slim backend requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         working-directory: frontend
         run: npm run test -- --coverage --run
 
-
       # -------------------------
       # Python setup
       # -------------------------
@@ -48,13 +47,57 @@ jobs:
             backend/requirements.txt
             u-stock-bots/requirements.txt
 
+      - name: Guard backend requirements for Vercel
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+
+          req_file = Path("backend/requirements.txt")
+          if not req_file.exists():
+              print("Missing backend/requirements.txt")
+              sys.exit(1)
+
+          banned = {
+              "yfinance",
+              "pandas",
+              "numpy",
+              "pyarrow",
+              "curl-cffi",
+              "sseclient-py",
+              "greenlet",
+              "multitasking",
+          }
+
+          found = []
+
+          for raw_line in req_file.read_text(encoding="utf-8").splitlines():
+              line = raw_line.split("#", 1)[0].strip()
+              if not line:
+                  continue
+
+              pkg = re.split(r"[<>=!~\[]", line, maxsplit=1)[0].strip().lower().replace("_", "-")
+              if pkg in banned:
+                  found.append(pkg)
+
+          if found:
+              for pkg in sorted(set(found)):
+                  print(f"Banned backend dependency detected: {pkg}")
+              sys.exit(1)
+
+          print("Backend requirements passed Vercel bundle guard.")
+          PY
+
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
           pip install -r u-stock-bots/requirements.txt
           pip install pytest pytest-cov
-
 
       # -------------------------
       # Backend tests
@@ -66,7 +109,6 @@ jobs:
           --cov-report=xml:coverage-backend.xml \
           --cov-report=term-missing
 
-
       # -------------------------
       # Bots tests
       # -------------------------
@@ -76,7 +118,6 @@ jobs:
           --cov=u-stock-bots \
           --cov-report=xml:u-stock-bots/coverage-bots.xml \
           --cov-report=term-missing
-
 
       # -------------------------
       # Upload artifacts

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,14 +12,12 @@ click==8.3.1
 colorama==0.4.6
 coverage==7.12.0
 cryptography==46.0.3
-curl_cffi==0.13.0
 deprecation==2.1.0
 dnspython==2.8.0
 email_validator==2.2.0
 fastapi==0.128.0
 frozendict==2.4.7
 gotrue==2.12.4
-greenlet==3.3.0
 h11==0.16.0
 h2==4.3.0
 hpack==4.1.0
@@ -31,10 +29,7 @@ iniconfig==2.3.0
 lxml==6.0.2
 msgpack==1.1.2
 multidict==6.7.0
-multitasking==0.0.12
-numpy==2.3.5
 packaging==25.0
-pandas==2.3.3
 passlib==1.7.4
 peewee==3.18.3
 pip-tools==7.5.3
@@ -46,7 +41,6 @@ propcache==0.4.1
 protobuf==6.33.1
 psycopg==3.3.2
 psycopg-binary==3.3.2
-pyarrow==22.0.0
 pycparser==2.23
 pydantic==2.10.6
 pydantic_core==2.27.2
@@ -69,7 +63,6 @@ six==1.17.0
 sniffio==1.3.1
 soupsieve==2.8
 SQLAlchemy==2.0.44
-sseclient-py==1.8.0
 starlette==0.50.0
 storage3==0.12.1
 StrEnum==0.4.15
@@ -88,4 +81,3 @@ websockets==15.0.1
 wheel==0.46.3
 yahooquery==2.4.1
 yarl==1.22.0
-yfinance==0.2.66

--- a/u-stock-bots/requirements.txt
+++ b/u-stock-bots/requirements.txt
@@ -12,14 +12,12 @@ click==8.3.1
 colorama==0.4.6
 coverage==7.12.0
 cryptography==46.0.3
-curl_cffi==0.13.0
 deprecation==2.1.0
 dnspython==2.8.0
 email_validator==2.2.0
 fastapi==0.128.0
 frozendict==2.4.7
 gotrue==2.12.4
-greenlet==3.3.0
 h11==0.16.0
 h2==4.3.0
 hpack==4.1.0
@@ -31,10 +29,8 @@ iniconfig==2.3.0
 lxml==6.0.2
 msgpack==1.1.2
 multidict==6.7.0
-multitasking==0.0.12
 numpy==2.3.5
 packaging==25.0
-pandas==2.3.3
 passlib==1.7.4
 peewee==3.18.3
 pip-tools==7.5.3
@@ -46,7 +42,6 @@ propcache==0.4.1
 protobuf==6.33.1
 psycopg==3.3.2
 psycopg-binary==3.3.2
-pyarrow==22.0.0
 pycparser==2.23
 pydantic==2.10.6
 pydantic_core==2.27.2
@@ -69,7 +64,6 @@ six==1.17.0
 sniffio==1.3.1
 soupsieve==2.8
 SQLAlchemy==2.0.44
-sseclient-py==1.8.0
 starlette==0.50.0
 storage3==0.12.1
 StrEnum==0.4.15
@@ -88,4 +82,3 @@ websockets==15.0.1
 wheel==0.46.3
 yahooquery==2.4.1
 yarl==1.22.0
-yfinance==0.2.66


### PR DESCRIPTION
Slims the Vercel FastAPI backend by removing heavy data-processing dependencies that are not used by backend code and belong in `u-stock-bots`.

Adds a CI guard to block large packages (`yfinance`, `pandas`, `numpy`, `pyarrow`, `curl_cffi`, `sseclient-py`, `greenlet`, `multitasking`) from being added to `backend/requirements.txt` in the future, preventing bundle-limit issues during deployment.